### PR TITLE
Add the possibility to insert HTML content in the 'MsgToEmail' rule-node

### DIFF
--- a/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.directive.js
+++ b/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.directive.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable import/no-unresolved, import/default */
+import deleteTimseriesFromDatabaseConfigTemplate from "./delete-timeseries-from-database-config.tpl.html";
+import "./delete-timeseries-from-database-config.scss";
+
+/*@ngInject*/
+export default function DeleteTimeseriesFromDatabaseDirective($compile, $mdConstant, ruleNodeTypes) {
+
+
+    var linker = function (scope, element, attrs, ngModelCtrl) {
+        var template = deleteTimseriesFromDatabaseConfigTemplate;
+        element.html(template);
+
+        const semicolon = 186;
+        scope.separatorKeys = [$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA, semicolon];
+
+        scope.ruleNodeTypes = ruleNodeTypes;
+
+        scope.aggPeriodTimeUnits = {};
+        scope.aggPeriodTimeUnits["MINUTES"] = ruleNodeTypes.timeUnit["MINUTES"];
+        scope.aggPeriodTimeUnits["HOURS"] = ruleNodeTypes.timeUnit["HOURS"];
+        scope.aggPeriodTimeUnits["DAYS"] = ruleNodeTypes.timeUnit["DAYS"];
+        scope.aggPeriodTimeUnits["MILLISECONDS"] = ruleNodeTypes.timeUnit["MILLISECONDS"];
+        scope.aggPeriodTimeUnits["SECONDS"] = ruleNodeTypes.timeUnit["SECONDS"];
+		
+        scope.$watch('configuration', function (newConfiguration, oldConfiguration) {
+            if (!angular.equals(newConfiguration, oldConfiguration)) {
+                ngModelCtrl.$setViewValue(scope.configuration);
+            }
+        });
+
+        ngModelCtrl.$render = function () {
+            scope.configuration = ngModelCtrl.$viewValue;
+        };
+
+        $compile(element.contents())(scope);
+    };
+
+    return {
+        restrict: "E",
+        require: "^ngModel",
+        scope: {},
+        link: linker
+    };
+}
+

--- a/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.scss
+++ b/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.scss
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.tb-telemetry-from-database-config {
+  .tb-time-unit {
+  }
+}

--- a/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.tpl.html
+++ b/src/app/rulenode/config/components/action/delete-timeseries-from-database-config.tpl.html
@@ -1,0 +1,99 @@
+<!--
+    Copyright © 2016-2018 The Thingsboard Authors
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<section class="tb-delete-timeseries-from-database-config" ng-form name="deleteTimeseriesConfigForm" layout="column">
+    <label translate class="tb-title no-padding">tb.rulenode.latest-timeseries</label>
+    <md-chips ng-required="false"
+              readonly="readonly"
+              ng-model="configuration.latestTsKeyNames"
+              placeholder="{{'tb.rulenode.latest-timeseries' | translate}}"
+              md-separator-keys="separatorKeys">
+    </md-chips>
+    <md-checkbox style="margin-top: 18px" aria-label="{{ 'tb.rulenode.delete-all-data' | translate }}"
+                 ng-model="configuration.deleteAllDataForKeys">
+        {{ 'tb.rulenode.delete-all-data' | translate }}
+    </md-checkbox>
+    <div class="tb-hint" translate>tb.rulenode.delete-all-data-hint</div>
+    <md-checkbox aria-label="{{ 'tb.rulenode.use-metadata-interval-patterns' | translate }}"
+                 ng-model="configuration.useMetadataIntervalPatterns">{{ 'tb.rulenode.use-metadata-interval-patterns' |
+        translate }}
+    </md-checkbox>
+    <div class="tb-hint" translate>tb.rulenode.use-metadata-interval-patterns-hint</div>
+    <div layout="column" layout-gt-sm="row">
+        <md-input-container flex class="md-block tb-time-value" 
+        					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns == false">
+            <label translate class="tb-title no-padding">tb.rulenode.start-interval</label>
+            <input required type="number" step="1" min="1" max="2147483647" name="startInterval"
+                   ng-model="configuration.startInterval">
+            <div ng-messages="deleteTimeseriesConfigForm.startInterval.$error">
+                <div translate ng-message="required">tb.rulenode.start-interval-value-required</div>
+                <div ng-message="min" translate>tb.rulenode.time-value-range</div>
+                <div ng-message="max" translate>tb.rulenode.time-value-range</div>
+            </div>
+        </md-input-container>
+        <md-input-container flex class="md-block tb-time-unit" 
+        					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns == false ">
+            <label translate class="tb-title no-padding">tb.rulenode.start-interval-time-unit</label>
+            <md-select required name="startIntervalTimeUnit"
+                       aria-label="{{ 'tb.rulenode.start-interval-time-unit' | translate }}"
+                       ng-model="configuration.startIntervalTimeUnit">
+                <md-option ng-repeat="timeUnit in ruleNodeTypes.timeUnit" ng-value="timeUnit.value">
+                    {{timeUnit.name | translate}}
+                </md-option>
+            </md-select>
+        </md-input-container>
+    </div>
+    <div layout="column" layout-gt-sm="row">
+        <md-input-container flex class="md-block tb-time-value" 
+        					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns == false">
+            <label translate class="tb-title no-padding">tb.rulenode.end-interval</label>
+            <input required type="number" step="1" min="1" max="2147483647" name="endInterval"
+                   ng-model="configuration.endInterval">
+            <div ng-messages="deleteTimeseriesConfigForm.endInterval.$error">
+                <div translate ng-message="required">tb.rulenode.end-interval-value-required</div>
+                <div ng-message="min" translate>tb.rulenode.time-value-range</div>
+                <div ng-message="max" translate>tb.rulenode.time-value-range</div>
+            </div>
+        </md-input-container>
+        <md-input-container flex class="md-block tb-time-unit" 
+        					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns === false">
+            <label translate class="tb-title no-padding">tb.rulenode.end-interval-time-unit</label>
+            <md-select required name="endIntervalTimeUnit"
+                       aria-label="{{ 'tb.rulenode.end-interval-time-unit' | translate }}"
+                       ng-model="configuration.endIntervalTimeUnit">
+                <md-option ng-repeat="timeUnit in ruleNodeTypes.timeUnit" ng-value="timeUnit.value">
+                    {{timeUnit.name | translate}}
+                </md-option>
+            </md-select>
+        </md-input-container>
+    </div>
+    <md-input-container class="md-block" flex 
+    					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns === true"
+                        style="margin-top: 38px;">
+        <label translate>tb.rulenode.start-interval-pattern</label>
+        <input ng-required="true" name="startIntervalPattern" ng-model="configuration.startIntervalPattern"/>
+        <div ng-messages="deleteTimeseriesConfigForm.startIntervalPattern.$error">
+            <div ng-message="required" translate>tb.rulenode.start-interval-pattern-required</div>
+        </div>
+        <div class="tb-hint" translate>tb.rulenode.start-interval-pattern-hint</div>
+    </md-input-container>
+    <md-input-container class="md-block" flex 
+    					ng-if="configuration.deleteAllDataForKeys == false && configuration.useMetadataIntervalPatterns === true">
+        <label translate>tb.rulenode.end-interval-pattern</label>
+        <input ng-required="true" name="endIntervalPattern" ng-model="configuration.endIntervalPattern"/>
+        <div ng-messages="deleteTimeseriesConfigForm.endIntervalPattern.$error">
+            <div ng-message="required" translate>tb.rulenode.end-interval-pattern-required</div>
+        </div>
+        <div class="tb-hint" translate>tb.rulenode.end-interval-pattern-hint</div>
+    </md-input-container>
+</section>

--- a/src/app/rulenode/config/components/action/index.js
+++ b/src/app/rulenode/config/components/action/index.js
@@ -38,6 +38,7 @@ import CreateRelationConfigDirective from './create-relation-config.directive';
 import saveToCustomTableConfigDirective from './save-to-custom-table-config.directive';
 import gpsGeoActionConfigDirective from './gps-geo-action-config.directive';
 import PubsubConfigDirective from "./pubsub-config.directive";
+import DeleteTimeseriesFromDatabaseDirective from "./delete-timeseries-from-database-config.directive";
 
 export default angular.module('thingsboard.ruleChain.config.action', [])
     .directive('tbActionNodeTimeseriesConfig', TimeseriesConfigDirective)
@@ -64,4 +65,5 @@ export default angular.module('thingsboard.ruleChain.config.action', [])
     .directive('tbActionNodeCustomTableConfig', saveToCustomTableConfigDirective)
     .directive('tbActionNodeGpsGeofencingConfig', gpsGeoActionConfigDirective)
     .directive('tbActionNodePubSubConfig', PubsubConfigDirective)
+    .directive('tbActionNodeDeleteTimeseriesFromDatabase', DeleteTimeseriesFromDatabaseDirective)
     .name;

--- a/src/app/rulenode/config/locale/rulenode-core-locale.constant.js
+++ b/src/app/rulenode/config/locale/rulenode-core-locale.constant.js
@@ -42,6 +42,8 @@ export default function addRuleNodeCoreLocaleEnglish($translateProvider) {
                 "end-interval": "End Interval",
                 "start-interval-time-unit": "Start Interval Time Unit",
                 "end-interval-time-unit": "End Interval Time Unit",
+                "delete-all-data": "Delete all data for keys",
+                "delete-all-data-hint": "If selected, all data for chosen keys are deleted regardless of specified time range",
                 "fetch-mode": "Fetch mode",
                 "fetch-mode-hint": "If selected fetch mode 'ALL'  you able to choose telemetry sampling order.",
                 "order-by": "Order by",


### PR DESCRIPTION
Thingsboard email service, based on MimeMessageHelper Spring framework, can interpret any HTML content in email body message. This option, if the relevant checkbox is set, should be as second parameter of setText() method: if not specified, the string used as text is displayed as a monospace font.