### PR TITLE
Add the possibility to insert HTML content in the 'MsgToEmail' rule-node

### DIFF
--- a/src/app/rulenode/config/components/transform/to-email-config.tpl.html
+++ b/src/app/rulenode/config/components/transform/to-email-config.tpl.html
@@ -51,6 +51,10 @@
         </div>
         <div class="tb-hint" translate>tb.rulenode.subject-template-hint</div>
     </md-input-container>
+    <md-checkbox flex aria-label="{{ \'tb.rulenode.html-content\' | translate }}"
+    			 ng-model=configuration.htmlContent>
+    	{{ \'tb.rulenode.html-content\' | translate }}
+    </md-checkbox>
     <md-input-container class="md-block">
         <label translate>tb.rulenode.body-template</label>
         <textarea ng-required="true" name="bodyTemplate" ng-model="configuration.bodyTemplate" rows="6"></textarea>

--- a/src/app/rulenode/config/locale/rulenode-core-locale.constant.js
+++ b/src/app/rulenode/config/locale/rulenode-core-locale.constant.js
@@ -145,6 +145,7 @@ export default function addRuleNodeCoreLocaleEnglish($translateProvider) {
                 "subject-template": "Subject Template",
                 "subject-template-required": "Subject Template is required",
                 "subject-template-hint": "Mail subject template, use <code>${metaKeyName}</code> to substitute variables from metadata",
+                "html-content":"Mail body has HTML content",
                 "body-template": "Body Template",
                 "body-template-required": "Body Template is required",
                 "body-template-hint": "Mail body template, use <code>${metaKeyName}</code> to substitute variables from metadata",


### PR DESCRIPTION
Thingsboard email service, based on MimeMessageHelper Spring framework, can interpret any HTML content in email body message. This option, if the relevant checkbox is set, should be as second parameter of setText() method: if not specified, the string used as text is displayed as a monospace font.